### PR TITLE
Add `serde` optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ license = "MIT"
 exclude = [".travis.yml"]
 
 [dependencies]
+serde = { version = "1.0.70", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0.24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,12 @@
 //! also need to adjust the β-value of the Rater instance accordingly:
 //! `Rater::new(1500.0/6.0)`.
 
+#[cfg(feature="serde")]
+extern crate serde;
+
+#[cfg(feature="serde")]
+mod serialization;
+
 use std::fmt;
 
 /// Rater is used to calculate rating updates given the β-parameter.

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,0 +1,17 @@
+use serde::{Serialize, Serializer};
+use Rating;
+use serde::ser::SerializeStruct;
+use serde::de::{self, Deserialize, Deserializer, Visitor, SeqAccess, MapAccess};
+
+impl Serialize for Rating {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Rating", 2)?;
+        state.serialize_field("mu", &self.mu)?;
+        state.serialize_field("sigma", &self.sigma)?;
+        state.end()
+    }
+}
+

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -2,6 +2,7 @@ use serde::{Serialize, Serializer};
 use Rating;
 use serde::ser::SerializeStruct;
 use serde::de::{self, Deserialize, Deserializer, Visitor, SeqAccess, MapAccess};
+use std::fmt;
 
 impl Serialize for Rating {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -15,3 +16,94 @@ impl Serialize for Rating {
     }
 }
 
+impl<'de> Deserialize<'de> for Rating {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field { Mu, Sigma };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("`mu` or `sigma`")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: de::Error,
+                    {
+                        match value {
+                            "mu" => Ok(Field::Mu),
+                            "sigma" => Ok(Field::Sigma),
+                            _ => Err(de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct RatingVisitor;
+
+        impl <'de> Visitor<'de> for RatingVisitor {
+            type Value = Rating;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Rating")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Rating, V::Error>
+            where
+                V: SeqAccess<'de>
+            {
+                let mu = seq.next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let sigma = seq.next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                Ok(Rating::new(mu, sigma))
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Rating, V::Error>
+            where
+                V: MapAccess<'de>
+            {
+                let mut mu = None;
+                let mut sigma = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Mu => {
+                            if mu.is_some() {
+                                return Err(de::Error::duplicate_field("mu"))
+                            } else {
+                                mu = Some(map.next_value()?);
+                            }
+                        }
+                        Field::Sigma => {
+                            if sigma.is_some() {
+                                return Err(de::Error::duplicate_field("sigma"))
+                            } else {
+                                sigma = Some(map.next_value()?);
+                            }
+                        }
+                    }
+                }
+                let mu = mu.ok_or_else(|| de::Error::missing_field("mu"))?;
+                let sigma = sigma.ok_or_else(|| de::Error::missing_field("sigma"))?;
+                Ok(Rating::new(mu, sigma))
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &["mu", "sigma"];
+        deserializer.deserialize_struct("Rating", FIELDS, RatingVisitor)
+    }
+}

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,8 +1,8 @@
-use serde::{Serialize, Serializer};
-use Rating;
+use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::SerializeStruct;
-use serde::de::{self, Deserialize, Deserializer, Visitor, SeqAccess, MapAccess};
+use serde::{Serialize, Serializer};
 use std::fmt;
+use Rating;
 
 impl Serialize for Rating {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -21,7 +21,10 @@ impl<'de> Deserialize<'de> for Rating {
     where
         D: Deserializer<'de>,
     {
-        enum Field { Mu, Sigma };
+        enum Field {
+            Mu,
+            Sigma,
+        };
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
@@ -55,7 +58,7 @@ impl<'de> Deserialize<'de> for Rating {
 
         struct RatingVisitor;
 
-        impl <'de> Visitor<'de> for RatingVisitor {
+        impl<'de> Visitor<'de> for RatingVisitor {
             type Value = Rating;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -64,7 +67,7 @@ impl<'de> Deserialize<'de> for Rating {
 
             fn visit_seq<V>(self, mut seq: V) -> Result<Rating, V::Error>
             where
-                V: SeqAccess<'de>
+                V: SeqAccess<'de>,
             {
                 let mu = seq.next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
@@ -75,7 +78,7 @@ impl<'de> Deserialize<'de> for Rating {
 
             fn visit_map<V>(self, mut map: V) -> Result<Rating, V::Error>
             where
-                V: MapAccess<'de>
+                V: MapAccess<'de>,
             {
                 let mut mu = None;
                 let mut sigma = None;
@@ -83,14 +86,14 @@ impl<'de> Deserialize<'de> for Rating {
                     match key {
                         Field::Mu => {
                             if mu.is_some() {
-                                return Err(de::Error::duplicate_field("mu"))
+                                return Err(de::Error::duplicate_field("mu"));
                             } else {
                                 mu = Some(map.next_value()?);
                             }
                         }
                         Field::Sigma => {
                             if sigma.is_some() {
-                                return Err(de::Error::duplicate_field("sigma"))
+                                return Err(de::Error::duplicate_field("sigma"));
                             } else {
                                 sigma = Some(map.next_value()?);
                             }
@@ -103,7 +106,7 @@ impl<'de> Deserialize<'de> for Rating {
             }
         }
 
-        const FIELDS: &'static [&'static str] = &["mu", "sigma"];
+        const FIELDS: &[&str] = &["mu", "sigma"];
         deserializer.deserialize_struct("Rating", FIELDS, RatingVisitor)
     }
 }

--- a/tests/rating_serialization.rs
+++ b/tests/rating_serialization.rs
@@ -1,0 +1,18 @@
+#![cfg(feature="serde")]
+/// Using a system test for serialization feature, as `serde_json` should not be included as a crate for builds, only for testing.
+
+extern crate serde;
+extern crate serde_json;
+extern crate bbt;
+
+use bbt::Rating;
+
+#[test]
+fn end_to_end() {
+    let original = Rating::default();
+
+    let serialized = serde_json::to_string(&original).unwrap_or_else(|_| panic!("Failed to serialize {:?}", original));
+    let deserialized: Rating = serde_json::from_str(&serialized).unwrap_or_else(|_| panic!("Failed to deserialize {}", &serialized));
+
+    assert_eq!(original, deserialized);
+}

--- a/tests/rating_serialization.rs
+++ b/tests/rating_serialization.rs
@@ -1,9 +1,8 @@
-#![cfg(feature="serde")]
+#![cfg(feature = "serde")]
+extern crate bbt;
 /// Using a system test for serialization feature, as `serde_json` should not be included as a crate for builds, only for testing.
-
 extern crate serde;
 extern crate serde_json;
-extern crate bbt;
 
 use bbt::Rating;
 
@@ -11,8 +10,10 @@ use bbt::Rating;
 fn end_to_end() {
     let original = Rating::default();
 
-    let serialized = serde_json::to_string(&original).unwrap_or_else(|_| panic!("Failed to serialize {:?}", original));
-    let deserialized: Rating = serde_json::from_str(&serialized).unwrap_or_else(|_| panic!("Failed to deserialize {}", &serialized));
+    let serialized = serde_json::to_string(&original)
+        .unwrap_or_else(|_| panic!("Failed to serialize {:?}", original));
+    let deserialized: Rating = serde_json::from_str(&serialized)
+        .unwrap_or_else(|_| panic!("Failed to deserialize {}", &serialized));
 
     assert_eq!(original, deserialized);
 }


### PR DESCRIPTION
This PR adds an optional `serde` feature which allows `Rating` to be [de]serialized. The serialized representation uses the `mu` and `sigma` fields, and deserialization restores the `sigma_sq` field using `Rating::new`, as referenced in #1.

`rustfmt` and `clippy` lints were also applied.